### PR TITLE
Add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+#### What is the purpose of this pull request?
+<!--- Describe your changes in detail. -->
+
+#### What problem is this solving?
+<!--- What is the motivation and context for this change? -->
+
+#### How should this be manually tested?
+<!--- Usually `yarn and yarn test`, but feel encouraged to add a more descriptive explanation. -->
+
+#### Screenshots or example usage
+<!-- Add screenshots that display the effects of your PR, especially when then involve visible aspects. -->
+
+#### Types of changes
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Quality improvement (tests or refactors)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
+- [ ] Requires change to documentation, which has been updated accordingly
+
+#### How does this PR make you feel? [:link:](http://giphy.com/)
+<!--- Insert a GIF that best describes your mood after finishing your PR: ![](GIF URL) -->


### PR DESCRIPTION
As the title says. Next time we open a PR, we'll have a template to fill in accordingly! :sparkles: 